### PR TITLE
Remove Usercheck Params

### DIFF
--- a/enclave_ops/ideep-enclave/Enclave/Enclave.edl
+++ b/enclave_ops/ideep-enclave/Enclave/Enclave.edl
@@ -45,7 +45,6 @@ enclave {
     trusted {
         public sgx_status_t ecall_conv_dnnl_function(
                                             [in, size=conv_desc_size] void* conv_desc, size_t conv_desc_size,
-                                            [user_check] void* conv_attr,
                                             [in, size=src_data_size] void* src_handle, size_t src_data_size,
                                             [in, size=src_desc_size] void* void_src_desc, size_t src_desc_size,
                                             [in, size=weight_data_size] void* weight_handle, size_t weight_data_size,

--- a/enclave_ops/ideep-enclave/Enclave/test.cpp
+++ b/enclave_ops/ideep-enclave/Enclave/test.cpp
@@ -135,7 +135,6 @@ static sgx_status_t AESGCM_decrypt_tensor (void* decrypt_handle,
 
 
 extern "C" sgx_status_t ecall_conv_dnnl_function (void* conv_desc, size_t conv_desc_size,
-                                        void* conv_attr,  //TODO: change to in/out
                                         void* src_handle, size_t src_data_size,
                                         void* void_src_desc, size_t src_desc_size,
                                         void* weight_handle, size_t weight_data_size,
@@ -154,9 +153,6 @@ extern "C" sgx_status_t ecall_conv_dnnl_function (void* conv_desc, size_t conv_d
     dnnl::convolution_forward::desc* conv_desc_mem = (dnnl::convolution_forward::desc*)conv_desc;
     dnnl::convolution_forward::desc* conv_desc_pri = (dnnl::convolution_forward::desc*)void_src_desc;
 
-    dnnl::primitive_attr conv_attr_mem;
-    dnnl::post_ops* ops = (dnnl::post_ops*)conv_attr;
-    conv_attr_mem.set_post_ops(*ops);
     auto conv_pd = dnnl::convolution_forward::primitive_desc(*conv_desc_mem, engine2);
     auto conv_pd_pri = dnnl::convolution_forward::primitive_desc(*conv_desc_pri, engine2);
 


### PR DESCRIPTION
Remove unused usercheck params to avoid secure problems.

Signed-off-by: Long, Hanyu <hanyu.long@intel.com>

