### PR TITLE
crypto code refine

### DIFF
--- a/enclave_ops/deployment/dkeycache/Enclave/enclave.config.xml
+++ b/enclave_ops/deployment/dkeycache/Enclave/enclave.config.xml
@@ -3,7 +3,7 @@
   <ISVSVN>0</ISVSVN>
   <StackMaxSize>0x40000</StackMaxSize>
   <HeapMaxSize>0xA00000</HeapMaxSize>
-  <TCSNum>8</TCSNum>
+  <TCSNum>1</TCSNum>
   <TCSPolicy>1</TCSPolicy>
   <DisableDebug>0</DisableDebug>
   <MiscSelect>0</MiscSelect>

--- a/enclave_ops/deployment/dkeycache/Enclave/enclave_ra.cpp
+++ b/enclave_ops/deployment/dkeycache/Enclave/enclave_ra.cpp
@@ -296,6 +296,7 @@ sgx_status_t enclave_verify_att_result_mac(sgx_ra_context_t context,
 {
     sgx_status_t ret;
     sgx_ec_key_128bit_t mk_key;
+    uint8_t mac[SGX_CMAC_MAC_SIZE] = {0};
 
     if(mac_size != sizeof(sgx_mac_t))
     {
@@ -309,8 +310,6 @@ sgx_status_t enclave_verify_att_result_mac(sgx_ra_context_t context,
     }
 
     do {
-        uint8_t mac[SGX_CMAC_MAC_SIZE] = {0};
-
         ret = sgx_ra_get_keys(context, SGX_RA_KEY_MK, &mk_key);
         if(SGX_SUCCESS != ret)
         {
@@ -333,6 +332,8 @@ sgx_status_t enclave_verify_att_result_mac(sgx_ra_context_t context,
     }
     while(0);
 
+    memset_s(&mk_key, sizeof(mk_key), 0, sizeof(mk_key));
+    memset_s(&mac, sizeof(mac), 0, sizeof(mac));
     return ret;
 }
 
@@ -409,6 +410,7 @@ sgx_status_t enclave_store_domainkey (
         // enclave is created again, the secret can be unsealed.
     } while(0);
 
+    memset_s(&sk_key, sizeof(sgx_ec_key_128bit_t), 0, sizeof(sgx_ec_key_128bit_t));
     return ret;
 }
 

--- a/enclave_ops/deployment/dkeycache/Enclave/marshal.cpp
+++ b/enclave_ops/deployment/dkeycache/Enclave/marshal.cpp
@@ -51,6 +51,7 @@ uint32_t marshal_input_parameters_e3_foo1(uint32_t target_fn_id, uint32_t msg_ty
     ms = (ms_in_msg_exchange_t *)malloc(ms_len);
     if(!ms)
     {
+        memset_s(temp_buff, param_len, 0, param_len);
         SAFE_FREE(temp_buff);
         return MALLOC_ERROR;
     }
@@ -60,6 +61,7 @@ uint32_t marshal_input_parameters_e3_foo1(uint32_t target_fn_id, uint32_t msg_ty
     memcpy(&ms->inparam_buff, temp_buff, param_len);
     *marshalled_buff = (uint8_t*)ms;
     *marshalled_buff_len = ms_len;
+    memset_s(temp_buff, param_len, 0, param_len);
     SAFE_FREE(temp_buff);
     return SUCCESS;
 }

--- a/enclave_ops/deployment/dkeycache/Makefile
+++ b/enclave_ops/deployment/dkeycache/Makefile
@@ -31,7 +31,7 @@
 
 include ../buildenv.mk
 
-SGX_DEBUG ?= 1
+SGX_DEBUG ?= 0
 
 App_Name := dkeycache
 Enclave_Name := libenclave-$(App_Name).so
@@ -161,8 +161,8 @@ App/enclave_u.h: $(SGX_EDGER8R) Enclave/enclave.edl
 App/enclave_u.c: App/enclave_u.h
 
 App/enclave_u.o: App/enclave_u.c
-	@$(CC) $(SGX_COMMON_CFLAGS) $(App_C_Flags) -c $< -o $@
-	@echo "CC   <=  $<"
+	@$(CXX) $(SGX_COMMON_CFLAGS) $(App_C_Flags) -c $< -o $@
+	@echo "CXX   <=  $<"
 
 App/%.o: App/%.cpp
 	@$(CXX) $(SGX_COMMON_CXXFLAGS) $(App_Cpp_Flags) -c $< -o $@
@@ -181,8 +181,8 @@ Enclave/enclave_t.h: $(SGX_EDGER8R) Enclave/enclave.edl
 Enclave/enclave_t.c: Enclave/enclave_t.h
 
 Enclave/enclave_t.o: Enclave/enclave_t.c
-	@$(CC) $(SGX_COMMON_CFLAGS) $(Enclave_C_Flags) -c $< -o $@
-	@echo "CC   <=  $<"
+	@$(CXX) $(SGX_COMMON_CFLAGS) $(Enclave_C_Flags) -c $< -o $@
+	@echo "CXX   <=  $<"
 
 Enclave/%.o: Enclave/%.cpp Enclave/enclave_t.h
 	@$(CXX) $(SGX_COMMON_CXXFLAGS) $(Enclave_Cpp_Flags) -c $< -o $@

--- a/enclave_ops/deployment/dkeyserver/App/ecp.cpp
+++ b/enclave_ops/deployment/dkeyserver/App/ecp.cpp
@@ -101,57 +101,44 @@ bool derive_key(
     sample_sha_state_handle_t sha_context;
     sample_sha256_hash_t key_material;
     
-    memset(&hash_buffer, 0, sizeof(hash_buffer_t));
+    sample_ret = sample_sha256_init(&sha_context);
+    if (sample_ret != SAMPLE_SUCCESS)
+        return false;
 
+    memset(&hash_buffer, 0, sizeof(hash_buffer_t));
     /* counter in big endian  */
     hash_buffer.counter[3] = key_id;
 
     /*convert from little endian to big endian */
     for (size_t i = 0; i < sizeof(sample_ec_dh_shared_t) ; i++)
-    {
         hash_buffer.shared_secret.s[i] = p_shared_key->s[sizeof(p_shared_key->s) - 1 - i];
-    }
 
-    sample_ret = sample_sha256_init(&sha_context);
-    if (sample_ret != SAMPLE_SUCCESS)
-    {
-        return false;
-    }
     sample_ret = sample_sha256_update((uint8_t*)&hash_buffer, sizeof(hash_buffer_t), sha_context);
     if (sample_ret != SAMPLE_SUCCESS)
-    {
-        sample_sha256_close(sha_context);
-        return false;
-    }
+        goto out;
+
     sample_ret = sample_sha256_update((uint8_t*)ID_U, sizeof(ID_U), sha_context);
     if (sample_ret != SAMPLE_SUCCESS)
-    {
-        sample_sha256_close(sha_context);
-        return false;
-    }
+        goto out;
+
     sample_ret = sample_sha256_update((uint8_t*)ID_V, sizeof(ID_V), sha_context);
     if (sample_ret != SAMPLE_SUCCESS)
-    {
-        sample_sha256_close(sha_context);
-        return false;
-    }
+        goto out;
+
     sample_ret = sample_sha256_get_hash(sha_context, &key_material);
     if (sample_ret != SAMPLE_SUCCESS)
-    {
-        sample_sha256_close(sha_context);
-        return false;
-    }
-    sample_ret = sample_sha256_close(sha_context);
+        goto out;
 
     static_assert(sizeof(sample_ec_key_128bit_t)* 2 == sizeof(sample_sha256_hash_t), "structure size mismatch.");
     memcpy_s(first_derived_key, sizeof(sample_ec_key_128bit_t), &key_material, sizeof(sample_ec_key_128bit_t));
     memcpy_s(second_derived_key, sizeof(sample_ec_key_128bit_t), (uint8_t*)&key_material + sizeof(sample_ec_key_128bit_t), sizeof(sample_ec_key_128bit_t));
 
-    // memset here can be optimized away by compiler, so please use memset_s on
-    // windows for production code and similar functions on other OSes.
-    memset(&key_material, 0, sizeof(sample_sha256_hash_t));
+out:
+    sample_ret = sample_sha256_close(sha_context)
+    explicit_bzero(&key_material, sizeof(sample_sha256_hash_t));
+    explicit_bzero(&hash_buffer, sizeof(hash_buffer_t));
 
-    return true;
+    return (SAMPLE_SUCCESS == sample_ret);
 }
 
 #else
@@ -185,9 +172,7 @@ bool derive_key(
         (sample_cmac_128bit_tag_t *)&key_derive_key);
     if (sample_ret != SAMPLE_SUCCESS)
     {
-        // memset here can be optimized away by compiler, so please use memset_s on
-        // windows for production code and similar functions on other OSes.
-        memset(&key_derive_key, 0, sizeof(key_derive_key));
+        explicit_bzero(&key_derive_key, sizeof(key_derive_key));
         return false;
     }
 
@@ -212,9 +197,7 @@ bool derive_key(
         label_length = sizeof(str_VK) -1;
         break;
     default:
-        // memset here can be optimized away by compiler, so please use memset_s on
-        // windows for production code and similar functions on other OSes.
-        memset(&key_derive_key, 0, sizeof(key_derive_key));
+        explicit_bzero(&key_derive_key, sizeof(key_derive_key));
         return false;
         break;
     }
@@ -223,9 +206,7 @@ bool derive_key(
     uint8_t *p_derivation_buffer = (uint8_t *)malloc(derivation_buffer_length);
     if (p_derivation_buffer == NULL)
     {
-        // memset here can be optimized away by compiler, so please use memset_s on
-        // windows for production code and similar functions on other OSes.
-        memset(&key_derive_key, 0, sizeof(key_derive_key));
+        explicit_bzero(&key_derive_key, sizeof(key_derive_key));
         return false;
     }
     memset(p_derivation_buffer, 0, derivation_buffer_length);
@@ -245,9 +226,7 @@ bool derive_key(
         derivation_buffer_length,
         (sample_cmac_128bit_tag_t *)derived_key);
     free(p_derivation_buffer);
-    // memset here can be optimized away by compiler, so please use memset_s on
-    // windows for production code and similar functions on other OSes.
-    memset(&key_derive_key, 0, sizeof(key_derive_key));
+    explicit_bzero(&key_derive_key, sizeof(key_derive_key));
     if (sample_ret != SAMPLE_SUCCESS)
     {
         return false;

--- a/enclave_ops/deployment/dkeyserver/App/rand.cpp
+++ b/enclave_ops/deployment/dkeyserver/App/rand.cpp
@@ -30,6 +30,7 @@
 */
 #include "rand.h"
 #include "ecp.h"
+#include <string.h>
 
 uint32_t g_drng_feature = 0;
 
@@ -109,12 +110,6 @@ static int drng_rand32(uint32_t *out)
             return rc;
     }
 
-    if (g_drng_feature & DRNG_HAS_RDRAND) {
-        rc = rdrand32(out);
-        if (0 != rc)
-            printf("failed with rdrand32\n");
-    }
-
     return rc;
 }
 
@@ -135,8 +130,11 @@ int get_random(uint8_t *buf, size_t len)
             return -1;
         }
 
-    if (0 != memcpy_s(buf + i, sizeof(tmp_buf), &tmp_buf, sizeof(tmp_buf)))
-        return -1;
+        if (0 != memcpy_s(buf + i, sizeof(tmp_buf), &tmp_buf, sizeof(tmp_buf))) {
+            explicit_bzero(&tmp_buf, sizeof(tmp_buf));
+            return -1;
+        }
+        explicit_bzero(&tmp_buf, sizeof(tmp_buf));
     }
 
     return 0;

--- a/enclave_ops/deployment/dkeyserver/App/socket_server.cpp
+++ b/enclave_ops/deployment/dkeyserver/App/socket_server.cpp
@@ -159,6 +159,9 @@ int sp_ra_proc_msg1_req(const sample_ra_msg1_t *p_msg1,
     sample_ecc_state_handle_t ecc_state = NULL;
     sample_status_t sample_ret = SAMPLE_SUCCESS;
     bool derive_ret = false;
+    sample_ec256_public_t pub_key = {{0},{0}};
+    sample_ec256_private_t priv_key = {{0}};
+    sample_ec_dh_shared_t dh_key = {{0}};
 
     if (!p_msg1 || !pp_msg2 || (msg1_size != sizeof(sample_ra_msg1_t))) {
         return -1;
@@ -195,8 +198,6 @@ int sp_ra_proc_msg1_req(const sample_ra_msg1_t *p_msg1,
             break;
         }
 
-        sample_ec256_public_t pub_key = {{0},{0}};
-        sample_ec256_private_t priv_key = {{0}};
         sample_ret = sample_ecc256_create_key_pair(&priv_key, &pub_key,
                                                    ecc_state);
         if (SAMPLE_SUCCESS != sample_ret)
@@ -223,7 +224,6 @@ int sp_ra_proc_msg1_req(const sample_ra_msg1_t *p_msg1,
         }
 
         // Generate the client/SP shared secret
-        sample_ec_dh_shared_t dh_key = {{0}};
         sample_ret = sample_ecc256_compute_shared_dhkey(&priv_key,
             (sample_ec256_public_t *)&p_msg1->g_a,
             (sample_ec256_dh_shared_t *)&dh_key,
@@ -399,6 +399,9 @@ int sp_ra_proc_msg1_req(const sample_ra_msg1_t *p_msg1,
         p_msg2->sig_rl_size = sig_rl_size;
 
     } while(0);
+
+    explicit_bzero(&priv_key, sizeof(priv_key));
+    explicit_bzero(&dh_key, sizeof(dh_key));
 
     if (ret)
     {

--- a/enclave_ops/deployment/dkeyserver/Enclave/enclave.config.xml
+++ b/enclave_ops/deployment/dkeyserver/Enclave/enclave.config.xml
@@ -3,7 +3,7 @@
   <ISVSVN>0</ISVSVN>
   <StackMaxSize>0x40000</StackMaxSize>
   <HeapMaxSize>0xA00000</HeapMaxSize>
-  <TCSNum>8</TCSNum>
+  <TCSNum>1</TCSNum>
   <TCSPolicy>1</TCSPolicy>
   <DisableDebug>0</DisableDebug>
   <MiscSelect>0</MiscSelect>

--- a/enclave_ops/deployment/dkeyserver/Makefile
+++ b/enclave_ops/deployment/dkeyserver/Makefile
@@ -31,7 +31,7 @@
 
 include ../buildenv.mk
 
-SGX_DEBUG ?= 1
+SGX_DEBUG ?= 0
 
 App_Name := dkeyserver
 Enclave_Name := libenclave-$(App_Name).so
@@ -161,8 +161,8 @@ App/enclave_u.h: $(SGX_EDGER8R) Enclave/enclave.edl
 App/enclave_u.c: App/enclave_u.h
 
 App/enclave_u.o: App/enclave_u.c
-	@$(CC) $(SGX_COMMON_CFLAGS) $(App_C_Flags) -c $< -o $@
-	@echo "CC   <=  $<"
+	@$(CXX) $(SGX_COMMON_CFLAGS) $(App_C_Flags) -c $< -o $@
+	@echo "CXX   <=  $<"
 
 App/%.o: App/%.cpp
 	@$(CXX) $(SGX_COMMON_CXXFLAGS) $(App_Cpp_Flags) -c $< -o $@
@@ -180,8 +180,8 @@ Enclave/enclave_t.h: $(SGX_EDGER8R) Enclave/enclave.edl
 Enclave/enclave_t.c: Enclave/enclave_t.h
 
 Enclave/enclave_t.o: Enclave/enclave_t.c
-	@$(CC) $(SGX_COMMON_CFLAGS) $(Enclave_C_Flags) -c $< -o $@
-	@echo "CC   <=  $<"
+	@$(CXX) $(SGX_COMMON_CFLAGS) $(Enclave_C_Flags) -c $< -o $@
+	@echo "CXX   <=  $<"
 
 Enclave/%.o: Enclave/%.cpp Enclave/enclave_t.h
 	@$(CXX) $(SGX_COMMON_CXXFLAGS) $(Enclave_Cpp_Flags) -c $< -o $@


### PR DESCRIPTION
The updates includes:
1. sanitize sensitive values
2. disable enclave logs by default
3. set enclave to single thread by default
4. remove rdrand and keep rdseed as the only random generator.
5. other minor fixes

Signed-off-by: Yang Huang <yang.huang@intel.com>

Fixes #{issue number}
