### PR TITLE
[DO NOT MERGE] Fix compiling errors for explicit_bzero

### DIFF
--- a/enclave_ops/deployment/dkeyserver/App/ecp.h
+++ b/enclave_ops/deployment/dkeyserver/App/ecp.h
@@ -32,6 +32,7 @@
 #ifndef _ECP_H
 #define _ECP_H
 
+#include <bsd/string.h>
 #include <stdint.h>
 #include <stdlib.h>
 

--- a/enclave_ops/deployment/dkeyserver/Makefile
+++ b/enclave_ops/deployment/dkeyserver/Makefile
@@ -72,6 +72,7 @@ App_Link_Flags := -L$(SGX_LIBRARY_PATH) -l$(Urts_Library_Name) \
 	-lpthread \
 	-lsgx_dcap_quoteverify \
 	-ldl \
+	-lbsd \
 	-lsgx_ukey_exchange \
 	-lsample_libcrypto -Lsample_libcrypto -Wl,-rpath=$(CURDIR)/sample_libcrypto
 


### PR DESCRIPTION
For some old version libc, there might be some errors
related to the API explicit_bzero(). In this case, the
library libbsd-devel can be used instead.

Require to install the dependency, e.g.
yum install libbsd-devel

Signed-off-by: Yang Huang <yang.huang@intel.com>

Fixes #{issue number}
